### PR TITLE
Fix #2 - Add usage info for running standalone

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,15 @@ Proxy server for debugging nREPL
 
 ## Usage
 
+Running inside this project or in a project where lambdaisland.nrepl-proxy
+has been added to deps.edn:
 ```
 clojure -X lambdaisland.nrepl-proxy/start :port 1234 :attach 5678
+```
+
+Running if from anywhere:
+```
+clojure -Sdeps '{:deps {com.lambdaisland/nrepl-proxy {:mvn/version "0.2.8-alpha"}}}' -X lambdaisland.nrepl-proxy/start :port 1234 :attach 5678
 ```
 
 This will listen for incoming connections on port 1234, and will connect through


### PR DESCRIPTION
Added info about running standalone by specifying dependency in the command as suggested in the linked issue. It adds a hardcoded version number to the README that must be kept in sync. It might be replaced by a version placeholder if you are concerned that it may get out of sync when new versions are released. Or maybe there is a release pipeline that can replace it automatically?